### PR TITLE
This commit fixes a crash on the WalletScreen caused by the `useTheme…

### DIFF
--- a/app/(p2p)/offer/[id].tsx
+++ b/app/(p2p)/offer/[id].tsx
@@ -79,7 +79,7 @@ export default function P2POfferDetailScreen() {
           <View style={styles.summaryRow}>
             <Text style={styles.summaryLabel}>Pour</Text>
             <Text style={styles.summaryValueBold}>{offer.toAmount.toLocaleString()} {offer.toCurrency}</Text>
-          </V>
+          </View>
         </View>
 
         <View style={styles.balanceCheckCard}>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from "expo-router"
 import { StatusBar } from "expo-status-bar"
 import { AuthProvider } from "@contexts/AuthContext"
+import { ThemeProvider } from "@contexts/ThemeContext"
 import { WalletProvider } from "@contexts/WalletContext"
 import { ExchangeProvider } from "@contexts/ExchangeContext"
 import { NotificationProvider } from "@contexts/NotificationContext"
@@ -15,33 +16,35 @@ import { PerformanceProvider } from "@contexts/PerformanceContext"
 export default function RootLayout() {
   return (
     <AuthProvider>
-      <AnalyticsProvider>
-        <LocationProvider>
-          <OfflineProvider>
-            <BackupProvider>
-              <NotificationProvider>
-                <MultiCurrencyProvider>
-                  <PerformanceProvider>
-                    <WalletProvider>
-                      <ExchangeProvider>
-                        <KYCProvider>
-                          <StatusBar style="auto" />
-                          <Stack screenOptions={{ headerShown: false }}>
-                            <Stack.Screen name="(auth)" />
-                            <Stack.Screen name="(tabs)" />
-                            <Stack.Screen name="(admin)" />
-                            <Stack.Screen name="(modals)" />
-                          </Stack>
-                        </KYCProvider>
-                      </ExchangeProvider>
-                    </WalletProvider>
-                  </PerformanceProvider>
-                </MultiCurrencyProvider>
-              </NotificationProvider>
-            </BackupProvider>
-          </OfflineProvider>
-        </LocationProvider>
-      </AnalyticsProvider>
+      <ThemeProvider>
+        <AnalyticsProvider>
+          <LocationProvider>
+            <OfflineProvider>
+              <BackupProvider>
+                <NotificationProvider>
+                  <MultiCurrencyProvider>
+                    <PerformanceProvider>
+                      <WalletProvider>
+                        <ExchangeProvider>
+                          <KYCProvider>
+                            <StatusBar style="auto" />
+                            <Stack screenOptions={{ headerShown: false }}>
+                              <Stack.Screen name="(auth)" />
+                              <Stack.Screen name="(tabs)" />
+                              <Stack.Screen name="(admin)" />
+                              <Stack.Screen name="(modals)" />
+                            </Stack>
+                          </KYCProvider>
+                        </ExchangeProvider>
+                      </WalletProvider>
+                    </PerformanceProvider>
+                  </MultiCurrencyProvider>
+                </NotificationProvider>
+              </BackupProvider>
+            </OfflineProvider>
+          </LocationProvider>
+        </AnalyticsProvider>
+      </ThemeProvider>
     </AuthProvider>
   )
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -65,3 +65,24 @@ export interface KYCDocument {
   reviewedAt?: string
   rejectionReason?: string
 }
+
+export interface ExchangeOffer {
+  id: string;
+  userId: string;
+  fromCurrency: string;
+  toCurrency: string;
+  fromAmount: number;
+  toAmount: number;
+  rate: number;
+  status: 'open' | 'closed' | 'cancelled';
+  createdAt: string;
+}
+
+export interface ExchangeOrder {
+  id: string;
+  offerId: string;
+  sellerId: string;
+  buyerId: string;
+  status: 'pending' | 'completed' | 'failed';
+  createdAt: string;
+}


### PR DESCRIPTION
…` hook being called without a `ThemeProvider` in the component tree.

The `ThemeProvider` has been added to the root layout (`app/_layout.tsx`), wrapping all other providers and the main app stack. This ensures the theme context is available to all components throughout the application.