### PR TITLE
This commit fixes two critical runtime errors:

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,19 +1,41 @@
-import { Stack } from "expo-router"
-import { StatusBar } from "expo-status-bar"
-import { AuthProvider } from "@contexts/AuthContext"
-import { ThemeProvider } from "@contexts/ThemeContext"
-import { WalletProvider } from "@contexts/WalletContext"
-import { ExchangeProvider } from "@contexts/ExchangeContext"
-import { NotificationProvider } from "@contexts/NotificationContext"
-import { LocationProvider } from "@contexts/LocationContext"
-import { KYCProvider } from "@contexts/KYCContext"
-import { AnalyticsProvider } from "@contexts/AnalyticsContext"
-import { BackupProvider } from "@contexts/BackupContext"
-import { OfflineProvider } from "@contexts/OfflineContext"
-import { MultiCurrencyProvider } from "@contexts/MultiCurrencyContext"
-import { PerformanceProvider } from "@contexts/PerformanceContext"
+import { Stack, SplashScreen } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { useFonts } from 'expo-font';
+import { useEffect } from 'react';
+
+import { AuthProvider } from "@contexts/AuthContext";
+import { ThemeProvider } from "@contexts/ThemeContext";
+import { WalletProvider } from "@contexts/WalletContext";
+import { ExchangeProvider } from "@contexts/ExchangeContext";
+import { NotificationProvider } from "@contexts/NotificationContext";
+import { LocationProvider } from "@contexts/LocationContext";
+import { KYCProvider } from "@contexts/KYCContext";
+import { AnalyticsProvider } from "@contexts/AnalyticsContext";
+import { BackupProvider } from "@contexts/BackupContext";
+import { OfflineProvider } from "@contexts/OfflineContext";
+import { MultiCurrencyProvider } from "@contexts/MultiCurrencyContext";
+import { PerformanceProvider } from "@contexts/PerformanceContext";
+
+// Prevent the splash screen from auto-hiding before asset loading is complete.
+SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
+  const [fontsLoaded, fontError] = useFonts({
+    'SpaceMono-Regular': require('../assets/fonts/SpaceMono-Regular.ttf'),
+  });
+
+  useEffect(() => {
+    if (fontsLoaded || fontError) {
+      // Hide the splash screen after the fonts have loaded or an error occurred
+      SplashScreen.hideAsync();
+    }
+  }, [fontsLoaded, fontError]);
+
+  // Prevent rendering until the font has loaded or an error was returned
+  if (!fontsLoaded && !fontError) {
+    return null;
+  }
+
   return (
     <AuthProvider>
       <ThemeProvider>
@@ -46,5 +68,5 @@ export default function RootLayout() {
         </AnalyticsProvider>
       </ThemeProvider>
     </AuthProvider>
-  )
+  );
 }

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -30,7 +30,8 @@ interface ThemeColors {
   success: string
   warning: string
   error: string
-  info: string // Gardé pour la compatibilité, mais mappé sur une couleur neutre
+  info: string
+  earthBrown: string
 }
 
 interface ThemeContextType {
@@ -50,7 +51,8 @@ const lightColors: ThemeColors = {
   success: afriChangeColors.success,
   warning: afriChangeColors.warning,
   error: afriChangeColors.error,
-  info: afriChangeColors.emeraldGreen, // Info mappé sur le vert
+  info: afriChangeColors.emeraldGreen,
+  earthBrown: afriChangeColors.earthBrown,
 }
 
 const darkColors: ThemeColors = {
@@ -65,6 +67,7 @@ const darkColors: ThemeColors = {
   warning: afriChangeColors.warning,
   error: afriChangeColors.error,
   info: afriChangeColors.emeraldGreen,
+  earthBrown: afriChangeColors.earthBrown,
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)


### PR DESCRIPTION
1.  **Fix Theme Color Typo:** The `earthBrown` color was added to the `ThemeColors` interface and color objects in `ThemeContext.tsx`. This resolves a TypeScript error where the property was used without being declared on the type.

2.  **Fix Font Loading Timeout:** Implemented the standard Expo font loading pattern in the root layout (`app/_layout.tsx`). The app now uses `useFonts` to load the 'SpaceMono-Regular' font and `SplashScreen.preventAutoHideAsync()` to keep the splash screen visible until the font is loaded or an error occurs. This prevents the `6000ms timeout exceeded` crash.