### PR TITLE
refactor: Replace Axios with native Fetch API

### DIFF
--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,0 +1,61 @@
+import * as SecureStore from 'expo-secure-store';
+import { API_BASE_URL } from '@/configuration/api';
+
+interface FetchOptions extends RequestInit {
+  headers?: HeadersInit & {
+    'Content-Type'?: string;
+    Authorization?: string;
+  };
+}
+
+/**
+ * A wrapper around the native fetch API that automatically adds
+ * the authorization token to the request headers.
+ *
+ * @param url The URL to fetch, relative to the API_BASE_URL.
+ * @param options The options for the fetch request.
+ * @returns The response from the server.
+ */
+export async function authorizedFetch(url: string, options: FetchOptions = {}): Promise<any> {
+  const token = await SecureStore.getItemAsync('auth_token');
+
+  const defaultHeaders: HeadersInit = {
+    'Content-Type': 'application/json',
+  };
+
+  if (token) {
+    defaultHeaders['Authorization'] = `Bearer ${token}`;
+  }
+
+  // Merge default headers with custom headers from options
+  const headers = { ...defaultHeaders, ...options.headers };
+
+  // For multipart/form-data, we need to let the browser set the Content-Type
+  if (options.body instanceof FormData) {
+    delete headers['Content-Type'];
+  }
+
+  const config: RequestInit = {
+    ...options,
+    headers,
+  };
+
+  try {
+    const response = await fetch(`${API_BASE_URL}${url}`, config);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ message: 'An unknown error occurred' }));
+      throw new Error(errorData.message || `Request failed with status ${response.status}`);
+    }
+
+    // Handle cases with no content
+    if (response.status === 204) {
+      return null;
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error('Fetch error:', error);
+    throw error;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@react-navigation/bottom-tabs": "^7.3.15",
         "@react-navigation/native": "^7.1.11",
         "@tanstack/react-query": "^5.80.7",
-        "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "crypto-js": "^4.2.0",
@@ -8186,33 +8185,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -11900,26 +11872,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -17185,12 +17137,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@react-navigation/bottom-tabs": "^7.3.15",
     "@react-navigation/native": "^7.1.11",
     "@tanstack/react-query": "^5.80.7",
-    "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "crypto-js": "^4.2.0",

--- a/services/AuthService.ts
+++ b/services/AuthService.ts
@@ -1,85 +1,81 @@
-import apiClient from "./apiClient"
-import { API_ENDPOINTS } from "@/configuration/api"
-import type { User } from "@/types"
+import apiClient from "./apiClient";
+import { API_ENDPOINTS } from "@/configuration/api";
+import type { User } from "@/types";
 
 interface RegisterData {
-  email: string
-  password: string
-  firstName: string
-  lastName: string
-  phone: string
-  country: string
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  country: string;
 }
 
+/**
+ * Service for authentication-related API calls.
+ * All methods now use the fetch-based apiClient.
+ */
 export const AuthService = {
   login: async (email: string, password: string): Promise<{ token: string; user: User }> => {
     try {
-      const response = await apiClient.post(API_ENDPOINTS.LOGIN, { email, password })
-      return response.data
+      // apiClient.post now returns the JSON data directly
+      return await apiClient.post(API_ENDPOINTS.LOGIN, { email, password });
     } catch (error) {
-      console.error("Login error:", error)
-      throw error
+      console.error("Login error:", error);
+      throw error;
     }
   },
 
   register: async (userData: RegisterData): Promise<{ token: string; user: User }> => {
     try {
-      const response = await apiClient.post(API_ENDPOINTS.REGISTER, userData)
-      return response.data
+      return await apiClient.post(API_ENDPOINTS.REGISTER, userData);
     } catch (error) {
-      console.error("Registration error:", error)
-      throw error
+      console.error("Registration error:", error);
+      throw error;
     }
   },
 
   logout: async (): Promise<void> => {
     try {
-      // The request interceptor handles the token
-      await apiClient.post(API_ENDPOINTS.LOGOUT)
+      await apiClient.post(API_ENDPOINTS.LOGOUT, {});
     } catch (error) {
-      // It's often safe to ignore logout errors (e.g., if token is already expired)
-      console.error("Logout error:", error)
+      console.error("Logout error:", error);
+      // It's often safe to ignore logout errors
     }
   },
 
   fetchUserProfile: async (): Promise<User> => {
     try {
-      const response = await apiClient.get(API_ENDPOINTS.PROFILE)
-      return response.data
+      return await apiClient.get(API_ENDPOINTS.PROFILE);
     } catch (error) {
-      console.error("Fetch user profile error:", error)
-      throw error
+      console.error("Fetch user profile error:", error);
+      throw error;
     }
   },
 
   updateProfile: async (data: Partial<User>): Promise<User> => {
     try {
-      const response = await apiClient.put(API_ENDPOINTS.PROFILE, data)
-      return response.data
+      return await apiClient.put(API_ENDPOINTS.PROFILE, data);
     } catch (error) {
-      console.error("Update profile error:", error)
-      throw error
+      console.error("Update profile error:", error);
+      throw error;
     }
   },
 
   uploadAvatar: async (imageUri: string): Promise<{ avatarUrl: string }> => {
-    const formData = new FormData()
+    const formData = new FormData();
     formData.append("avatar", {
       uri: imageUri,
       type: "image/jpeg",
       name: "avatar.jpg",
-    } as any)
+    } as any);
 
     try {
-      const response = await apiClient.post("/users/avatar", formData, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      })
-      return response.data
+      // Use the dedicated method for form-data
+      return await apiClient.postFormData("/users/avatar", formData);
     } catch (error) {
-      console.error("Upload avatar error:", error)
-      throw error
+      console.error("Upload avatar error:", error);
+      throw error;
     }
   },
-}
+};

--- a/services/DepositService.ts
+++ b/services/DepositService.ts
@@ -1,34 +1,43 @@
-import apiClient from "./apiClient"
-import { API_ENDPOINTS } from "@/configuration/api"
-import type { Deposit } from "@/types" // Assuming a Deposit type exists
+import apiClient from "./apiClient";
+import { API_ENDPOINTS } from "@/configuration/api";
+import type { Deposit } from "@/types";
 
+/**
+ * Service for deposit-related API calls.
+ */
 export const DepositService = {
-  // Récupérer les dépôts d'un utilisateur
+  /**
+   * Fetches the deposit history for a user.
+   */
   getUserDeposits: async (userId: string): Promise<Deposit[]> => {
-    const response = await apiClient.get(API_ENDPOINTS.DEPOSITS + `/${userId}`)
-    return response.data
+    return apiClient.get(`${API_ENDPOINTS.DEPOSITS}/${userId}`);
   },
 
-  // Créer un nouveau dépôt
+  /**
+   * Creates a new deposit request.
+   */
   createDeposit: async (userId: string, depositData: any): Promise<Deposit> => {
-    const response = await apiClient.post(API_ENDPOINTS.DEPOSITS + `/${userId}`, depositData)
-    return response.data
+    return apiClient.post(`${API_ENDPOINTS.DEPOSITS}/${userId}`, depositData);
   },
 
-  // Récupérer les méthodes de paiement
+  /**
+   * Fetches the available payment methods for deposits.
+   */
   getPaymentMethods: async (): Promise<any[]> => {
-    const response = await apiClient.get(API_ENDPOINTS.DEPOSITS + "/payment-methods")
-    return response.data
+    return apiClient.get(`${API_ENDPOINTS.DEPOSITS}/payment-methods`);
   },
 
-  // Récupérer un dépôt spécifique
+  /**
+   * Fetches the details of a specific deposit.
+   */
   getDepositDetails: async (depositId: string): Promise<Deposit> => {
-    const response = await apiClient.get(`${API_ENDPOINTS.DEPOSITS}/${depositId}/users`)
-    return response.data
+    return apiClient.get(`${API_ENDPOINTS.DEPOSITS}/${depositId}/users`);
   },
 
-  // Annuler un dépôt
+  /**
+   * Cancels a pending deposit.
+   */
   cancelDeposit: async (depositId: string): Promise<void> => {
-    await apiClient.put(`${API_ENDPOINTS.DEPOSITS}/${depositId}/cancel`)
+    return apiClient.put(`${API_ENDPOINTS.DEPOSITS}/${depositId}/cancel`, {});
   },
-}
+};

--- a/services/ExchangeService.ts
+++ b/services/ExchangeService.ts
@@ -1,64 +1,58 @@
-import apiClient from "./apiClient"
-import { API_ENDPOINTS } from "@/configuration/api"
-import type { ExchangeOffer, ExchangeOrder, ExchangeRate } from "@/types" // Assuming types exist
+import apiClient from "./apiClient";
+import { API_ENDPOINTS } from "@/configuration/api";
+import type { ExchangeOffer, ExchangeOrder, ExchangeRate } from "@/types";
 
+/**
+ * Service for handling exchange offers and orders.
+ */
 export const ExchangeService = {
   // === Exchange Offers ===
 
   createOffer: async (offerData: any): Promise<ExchangeOffer> => {
-    const response = await apiClient.post(API_ENDPOINTS.EXCHANGE_OFFERS, offerData)
-    return response.data
+    return apiClient.post(API_ENDPOINTS.EXCHANGE_OFFERS, offerData);
   },
 
   getOpenOffers: async (): Promise<ExchangeOffer[]> => {
-    const response = await apiClient.get(API_ENDPOINTS.EXCHANGE_OFFERS)
-    return response.data
+    return apiClient.get(API_ENDPOINTS.EXCHANGE_OFFERS);
   },
 
   getOffersByUser: async (userId: string): Promise<ExchangeOffer[]> => {
-    const response = await apiClient.get(API_ENDPOINTS.EXCHANGE_OFFERS_BY_USER(userId))
-    return response.data
+    return apiClient.get(API_ENDPOINTS.EXCHANGE_OFFERS_BY_USER(userId));
   },
 
   cancelOffer: async (offerId: string): Promise<void> => {
-    await apiClient.delete(API_ENDPOINTS.CANCEL_EXCHANGE_OFFER(offerId))
+    return apiClient.delete(API_ENDPOINTS.CANCEL_EXCHANGE_OFFER(offerId));
   },
 
   // === Exchange Orders ===
 
   createOrder: async (orderData: any): Promise<ExchangeOrder> => {
-    const response = await apiClient.post(API_ENDPOINTS.EXCHANGE_ORDERS, orderData)
-    return response.data
+    return apiClient.post(API_ENDPOINTS.EXCHANGE_ORDERS, orderData);
   },
 
   getOpenOrders: async (): Promise<ExchangeOrder[]> => {
-    const response = await apiClient.get(API_ENDPOINTS.EXCHANGE_ORDERS)
-    return response.data
+    return apiClient.get(API_ENDPOINTS.EXCHANGE_ORDERS);
   },
 
   getOrdersByUser: async (userId: string): Promise<ExchangeOrder[]> => {
-    const response = await apiClient.get(API_ENDPOINTS.EXCHANGE_ORDERS_BY_USER(userId))
-    return response.data
+    return apiClient.get(API_ENDPOINTS.EXCHANGE_ORDERS_BY_USER(userId));
   },
 
   cancelOrder: async (orderId: string): Promise<void> => {
-    await apiClient.delete(API_ENDPOINTS.CANCEL_EXCHANGE_ORDER(orderId))
+    return apiClient.delete(API_ENDPOINTS.CANCEL_EXCHANGE_ORDER(orderId));
   },
 
   // === Internal Exchange Rates ===
 
   getInternalRates: async (): Promise<ExchangeRate[]> => {
-    const response = await apiClient.get(API_ENDPOINTS.INTERNAL_EXCHANGE_RATES)
-    return response.data
+    return apiClient.get(API_ENDPOINTS.INTERNAL_EXCHANGE_RATES);
   },
 
   createInternalRate: async (rateData: any): Promise<ExchangeRate> => {
-    const response = await apiClient.post(API_ENDPOINTS.INTERNAL_EXCHANGE_RATES, rateData)
-    return response.data
+    return apiClient.post(API_ENDPOINTS.INTERNAL_EXCHANGE_RATES, rateData);
   },
 
   getSpecificRate: async (from: string, to: string): Promise<ExchangeRate> => {
-    const response = await apiClient.get(API_ENDPOINTS.GET_SPECIFIC_RATE(from, to))
-    return response.data
+    return apiClient.get(API_ENDPOINTS.GET_SPECIFIC_RATE(from, to));
   },
-}
+};

--- a/services/ProfileService.ts
+++ b/services/ProfileService.ts
@@ -1,34 +1,43 @@
-import apiClient from "./apiClient"
-import { API_ENDPOINTS } from "@/configuration/api"
-import type { UserSettings } from "@/types" // Assuming a UserSettings type exists
+import apiClient from "./apiClient";
+import { API_ENDPOINTS } from "@/configuration/api";
+import type { UserSettings } from "@/types";
 
+/**
+ * Service for user profile and settings API calls.
+ */
 export const ProfileService = {
-  // Récupérer les paramètres de l'utilisateur
+  /**
+   * Fetches the settings for the authenticated user.
+   */
   getUserSettings: async (): Promise<UserSettings> => {
-    const response = await apiClient.get(API_ENDPOINTS.USER_SETTINGS)
-    return response.data
+    return apiClient.get(API_ENDPOINTS.USER_SETTINGS);
   },
 
-  // Mettre à jour les paramètres de l'utilisateur
+  /**
+   * Updates the settings for the authenticated user.
+   */
   updateUserSettings: async (settingsData: Partial<UserSettings>): Promise<UserSettings> => {
-    const response = await apiClient.put(API_ENDPOINTS.USER_SETTINGS, settingsData)
-    return response.data
+    return apiClient.put(API_ENDPOINTS.USER_SETTINGS, settingsData);
   },
 
-  // Récupérer les statistiques du profil
+  /**
+   * Fetches profile statistics for the user.
+   */
   getProfileStats: async (): Promise<any> => {
-    const response = await apiClient.get(API_ENDPOINTS.PROFILE_STATS)
-    return response.data
+    return apiClient.get(API_ENDPOINTS.PROFILE_STATS);
   },
 
-  // Exporter les données de l'utilisateur
+  /**
+   * Requests an export of the user's data.
+   */
   exportUserData: async (): Promise<any> => {
-    const response = await apiClient.post(API_ENDPOINTS.EXPORT_USER_DATA)
-    return response.data // This might be a file or a link
+    return apiClient.post(API_ENDPOINTS.EXPORT_USER_DATA, {});
   },
 
-  // Supprimer le compte de l'utilisateur
+  /**
+   * Deletes the user's account.
+   */
   deleteUserAccount: async (): Promise<void> => {
-    await apiClient.delete(API_ENDPOINTS.DELETE_USER_ACCOUNT)
+    return apiClient.delete(API_ENDPOINTS.DELETE_USER_ACCOUNT);
   },
-}
+};

--- a/services/TransactionService.ts
+++ b/services/TransactionService.ts
@@ -1,56 +1,63 @@
-import apiClient from "./apiClient"
-import { API_ENDPOINTS } from "@/configuration/api"
-import type { Transaction } from "@/types" // Assuming a Transaction type exists
+import apiClient from "./apiClient";
+import { API_ENDPOINTS } from "@/configuration/api";
+import type { Transaction } from "@/types";
 
 interface TransferData {
-  receiverEmail: string
-  amount: number
-  currency: string
-  description?: string
+  receiverEmail: string;
+  amount: number;
+  currency: string;
+  description?: string;
 }
 
+/**
+ * Service for handling financial transactions.
+ */
 export const TransactionService = {
-  // Récupérer la liste des transactions de l'utilisateur
+  /**
+   * Fetches the transaction history for the authenticated user.
+   */
   getUserTransactions: async (): Promise<Transaction[]> => {
     try {
-      const response = await apiClient.get(API_ENDPOINTS.TRANSACTIONS)
-      return response.data
+      return await apiClient.get(API_ENDPOINTS.TRANSACTIONS);
     } catch (error) {
-      console.error("Error fetching user transactions:", error)
-      throw error
+      console.error("Error fetching user transactions:", error);
+      throw error;
     }
   },
 
-  // Récupérer les détails d'une transaction spécifique
+  /**
+   * Fetches the details of a specific transaction.
+   */
   getTransactionDetails: async (transactionId: string): Promise<Transaction> => {
     try {
-      const response = await apiClient.get(`${API_ENDPOINTS.TRANSACTIONS}/${transactionId}`)
-      return response.data
+      return await apiClient.get(`${API_ENDPOINTS.TRANSACTIONS}/${transactionId}`);
     } catch (error) {
-      console.error(`Error fetching transaction details for ID ${transactionId}:`, error)
-      throw error
+      console.error(`Error fetching transaction details for ID ${transactionId}:`, error);
+      throw error;
     }
   },
 
-  // Créer un transfert de fonds
+  /**
+   * Creates a new fund transfer to another user.
+   */
   createTransfer: async (transferData: TransferData): Promise<Transaction> => {
     try {
-      const response = await apiClient.post(`${API_ENDPOINTS.TRANSACTIONS}/transfer`, transferData)
-      return response.data
+      return await apiClient.post(`${API_ENDPOINTS.TRANSACTIONS}/transfer`, transferData);
     } catch (error) {
-      console.error("Error creating transfer:", error)
-      throw error
+      console.error("Error creating transfer:", error);
+      throw error;
     }
   },
 
-  // Obtenir les statistiques des transactions
+  /**
+   * Fetches transaction statistics.
+   */
   getTransactionStats: async (): Promise<any> => {
     try {
-      const response = await apiClient.get(`${API_ENDPOINTS.TRANSACTIONS}/statistique/stats`)
-      return response.data
+      return await apiClient.get(`${API_ENDPOINTS.TRANSACTIONS}/statistique/stats`);
     } catch (error) {
-      console.error("Error fetching transaction stats:", error)
-      throw error
+      console.error("Error fetching transaction stats:", error);
+      throw error;
     }
   },
-}
+};

--- a/services/WalletService.ts
+++ b/services/WalletService.ts
@@ -1,72 +1,81 @@
-import apiClient from "./apiClient"
-import { API_ENDPOINTS } from "@/configuration/api"
-import type { Wallet, Currency } from "@/types" // Assuming a Wallet type exists in types/index.ts
+import apiClient from "./apiClient";
+import { API_ENDPOINTS } from "@/configuration/api";
+import type { Wallet, Currency } from "@/types";
 
+/**
+ * Service for wallet-related API calls.
+ * All methods now use the fetch-based apiClient.
+ */
 export const WalletService = {
-  // Récupérer tous les portefeuilles de l'utilisateur
-  getUserWallets: async (): Promise<{ wallets: Wallet[], totalBalanceUSD: number }> => {
+  /**
+   * Fetches all wallets for the authenticated user.
+   */
+  getUserWallets: async (): Promise<{ wallets: Wallet[]; totalBalanceUSD: number }> => {
     try {
-      const response = await apiClient.get(API_ENDPOINTS.WALLETS)
-      // The API is expected to return { wallets: Wallet[], totalBalanceUSD: number }
-      return response.data
+      return await apiClient.get(API_ENDPOINTS.WALLETS);
     } catch (error) {
-      console.error("Error fetching user wallets:", error)
-      throw error
+      console.error("Error fetching user wallets:", error);
+      throw error;
     }
   },
 
-  // Get all supported currencies
+  /**
+   * Fetches all supported currencies.
+   */
   getCurrencies: async (): Promise<Currency[]> => {
     try {
-      const response = await apiClient.get(API_ENDPOINTS.CURRENCIES)
-      return response.data
+      return await apiClient.get(API_ENDPOINTS.CURRENCIES);
     } catch (error) {
-      console.error("Error fetching currencies:", error)
-      throw error
+      console.error("Error fetching currencies:", error);
+      throw error;
     }
   },
 
-  // Créer un nouveau portefeuille pour un utilisateur
+  /**
+   * Creates a new wallet for a user.
+   */
   createWallet: async (userId: string, currency: string): Promise<Wallet> => {
     try {
-      const response = await apiClient.post(API_ENDPOINTS.WALLETS + `/${userId}`, { currency })
-      return response.data
+      return await apiClient.post(`${API_ENDPOINTS.WALLETS}/${userId}`, { currency });
     } catch (error) {
-      console.error("Error creating wallet:", error)
-      throw error
+      console.error("Error creating wallet:", error);
+      throw error;
     }
   },
 
-  // Récupérer un portefeuille par devise
+  /**
+   * Fetches a specific wallet by currency for a user.
+   */
   getWalletByCurrency: async (userId: string, currency: string): Promise<Wallet> => {
     try {
-      const response = await apiClient.get(API_ENDPOINTS.WALLETS + `/${userId}/${currency}`)
-      return response.data
+      return await apiClient.get(`${API_ENDPOINTS.WALLETS}/${userId}/${currency}`);
     } catch (error) {
-      console.error(`Error fetching wallet for currency ${currency}:`, error)
-      throw error
+      console.error(`Error fetching wallet for currency ${currency}:`, error);
+      throw error;
     }
   },
 
-  // Obtenir le solde d'un portefeuille
+  /**
+   * Fetches the balance for a specific wallet.
+   */
   getWalletBalance: async (userId: string, currency: string): Promise<{ balance: number }> => {
     try {
-      const response = await apiClient.get(API_ENDPOINTS.WALLETS + `/${currency}/balance/${userId}`)
-      return response.data
+      return await apiClient.get(`${API_ENDPOINTS.WALLETS}/${currency}/balance/${userId}`);
     } catch (error) {
-      console.error(`Error fetching balance for wallet ${currency}:`, error)
-      throw error
+      console.error(`Error fetching balance for wallet ${currency}:`, error);
+      throw error;
     }
   },
 
-  // Obtenir les statistiques d'un portefeuille
+  /**
+   * Fetches statistics for a specific wallet.
+   */
   getWalletStats: async (userId: string, currency: string): Promise<any> => {
     try {
-      const response = await apiClient.get(API_ENDPOINTS.WALLETS + `/stats/${userId}/${currency}`)
-      return response.data
+      return await apiClient.get(`${API_ENDPOINTS.WALLETS}/stats/${userId}/${currency}`);
     } catch (error) {
-      console.error(`Error fetching stats for wallet ${currency}:`, error)
-      throw error
+      console.error(`Error fetching stats for wallet ${currency}:`, error);
+      throw error;
     }
   },
-}
+};

--- a/services/WithdrawalService.ts
+++ b/services/WithdrawalService.ts
@@ -1,23 +1,29 @@
-import apiClient from "./apiClient"
-import { API_ENDPOINTS } from "@/configuration/api"
-import type { Withdrawal } from "@/types" // Assuming a Withdrawal type exists
+import apiClient from "./apiClient";
+import { API_ENDPOINTS } from "@/configuration/api";
+import type { Withdrawal } from "@/types";
 
+/**
+ * Service for handling withdrawal requests.
+ */
 export const WithdrawalService = {
-  // Créer une demande de retrait
+  /**
+   * Creates a new withdrawal request.
+   */
   createWithdrawal: async (withdrawalData: any): Promise<Withdrawal> => {
-    const response = await apiClient.post(API_ENDPOINTS.WITHDRAWALS, withdrawalData)
-    return response.data
+    return apiClient.post(API_ENDPOINTS.WITHDRAWALS, withdrawalData);
   },
 
-  // Lister les retraits d'un utilisateur
+  /**
+   * Lists all withdrawals for a specific user.
+   */
   getWithdrawalsByUser: async (userId: string): Promise<Withdrawal[]> => {
-    const response = await apiClient.get(API_ENDPOINTS.WITHDRAWALS_BY_USER(userId))
-    return response.data
+    return apiClient.get(API_ENDPOINTS.WITHDRAWALS_BY_USER(userId));
   },
 
-  // Mettre à jour le statut d'un retrait (pour admin)
+  /**
+   * Updates the status of a withdrawal (for admin use).
+   */
   updateWithdrawalStatus: async (withdrawalId: string, status: string): Promise<Withdrawal> => {
-    const response = await apiClient.put(API_ENDPOINTS.UPDATE_WITHDRAWAL_STATUS(withdrawalId), { status })
-    return response.data
+    return apiClient.put(API_ENDPOINTS.UPDATE_WITHDRAWAL_STATUS(withdrawalId), { status });
   },
-}
+};

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -1,26 +1,43 @@
-import axios from "axios"
-import * as SecureStore from "expo-secure-store"
-import { API_BASE_URL } from "@/configuration/api"
+import { authorizedFetch } from '@/lib/fetch';
 
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    "Content-Type": "application/json",
+/**
+ * A simple API client that uses the authorizedFetch utility
+ * to make requests. This provides a consistent interface for
+ * making API calls throughout the application.
+ */
+const apiClient = {
+  get: (url: string, options = {}) => {
+    return authorizedFetch(url, { ...options, method: 'GET' });
   },
-})
 
-// Ajouter un intercepteur pour inclure le token d'authentification
-apiClient.interceptors.request.use(
-  async (config) => {
-    const token = await SecureStore.getItemAsync("auth_token")
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
+  post: (url: string, data: any, options = {}) => {
+    return authorizedFetch(url, {
+      ...options,
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
   },
-  (error) => {
-    return Promise.reject(error)
-  },
-)
 
-export default apiClient
+  put: (url: string, data: any, options = {}) => {
+    return authorizedFetch(url, {
+      ...options,
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  },
+
+  delete: (url: string, options = {}) => {
+    return authorizedFetch(url, { ...options, method: 'DELETE' });
+  },
+
+  // A special method for multipart/form-data uploads
+  postFormData: (url: string, formData: FormData, options = {}) => {
+    return authorizedFetch(url, {
+      ...options,
+      method: 'POST',
+      body: formData,
+    });
+  },
+};
+
+export default apiClient;

--- a/services/p2pService.ts
+++ b/services/p2pService.ts
@@ -27,6 +27,10 @@ const MOCKED_STATS: TradeStats = {
 
 type CreateOfferPayload = Omit<P2POffer, 'id' | 'userId' | 'status' | 'createdAt' | 'matchedWith'>;
 
+/**
+ * Service for Peer-to-Peer (P2P) trading.
+ * NOTE: This service currently uses mocked data. The real API calls are commented out.
+ */
 export const P2PService = {
   /**
    * Fetches open P2P offers from the market.
@@ -34,8 +38,7 @@ export const P2PService = {
   getOpenOffers: async (): Promise<P2POffer[]> => {
     console.log('Fetching open P2P offers...');
     // Real implementation:
-    // const response = await apiClient.get(API_ENDPOINTS.EXCHANGE_OFFERS);
-    // return response.data;
+    // return await apiClient.get(API_ENDPOINTS.EXCHANGE_OFFERS);
 
     // Mock implementation:
     return new Promise(resolve => setTimeout(() => resolve(MOCKED_OFFERS), 1000));
@@ -48,8 +51,7 @@ export const P2PService = {
   createOffer: async (offerData: CreateOfferPayload): Promise<P2POffer> => {
     console.log('Creating P2P offer with data:', offerData);
     // Real implementation:
-    // const response = await apiClient.post(API_ENDPOINTS.EXCHANGE_OFFERS, offerData);
-    // return response.data;
+    // return await apiClient.post(API_ENDPOINTS.EXCHANGE_OFFERS, offerData);
 
     // Mock implementation:
     const newOffer: P2POffer = {
@@ -69,8 +71,7 @@ export const P2PService = {
   acceptOffer: async (offerId: string): Promise<{ success: boolean }> => {
     console.log(`Accepting offer with ID: ${offerId}`);
     // Real implementation:
-    // const response = await apiClient.post(API_ENDPOINTS.EXCHANGE_ORDERS, { offerId });
-    // return response.data;
+    // return await apiClient.post(API_ENDPOINTS.EXCHANGE_ORDERS, { offerId });
 
     // Mock implementation:
     return new Promise(resolve => setTimeout(() => resolve({ success: true }), 1000));
@@ -82,8 +83,8 @@ export const P2PService = {
   getTradeStats: async (): Promise<TradeStats> => {
     console.log('Fetching trade stats...');
     // Real implementation:
-    // const response = await apiClient.get(API_ENDPOINTS.P2P_STATS); // Assuming an endpoint exists
-    // return response.data;
+    // const P2P_STATS_ENDPOINT = '/p2p/stats'; // Assuming an endpoint exists
+    // return await apiClient.get(P2P_STATS_ENDPOINT);
 
     // Mock implementation:
     return new Promise(resolve => setTimeout(() => resolve(MOCKED_STATS), 1000));


### PR DESCRIPTION
This commit replaces all instances of Axios with a native `fetch`-based implementation to ensure compatibility with Expo's bridgeless architecture and to modernize the networking layer.

A new centralized `authorizedFetch` utility has been created in `lib/fetch.ts`. This utility wraps the native `fetch` API to automatically handle:
- Setting the `Content-Type: application/json` header.
- Injecting the `Authorization` token from `SecureStore`.
- Standardizing response and error handling.
- Handling `multipart/form-data` for file uploads.

The `services/apiClient.ts` has been refactored to use this new utility, providing a consistent `get`, `post`, `put`, `delete` interface for all services.

All services in the `services/` directory that previously used the Axios-based `apiClient` have been updated to use the new `fetch`-based implementation. Services that were already using `fetch` for external APIs were left untouched.

Finally, the `axios` dependency has been completely removed from the project. The existing test suite passes, confirming that the refactoring did not introduce any regressions.